### PR TITLE
Remove userId from Request Body and Fetch from JWT Token

### DIFF
--- a/server/controllers/imageController.js
+++ b/server/controllers/imageController.js
@@ -4,8 +4,11 @@ import axios from "axios";
 
 export const generateImage = async (req, res) => {
     try {
-      const { userId, prompt } = req.body;
-      console.log("Received request with:", { userId, prompt });
+      const { prompt } = req.body;
+      
+      console.log("Received request with:", { prompt });
+      const userId=req.user.id;
+    
   
       const user = await userModel.findById(userId);
       if (!user || !prompt) {


### PR DESCRIPTION
Chnages:
Removed userId destructuring from req.body.
Updated the code to retrieve userId from req.user.id instead.

The userId was previously included in the request body, which is unnecessary and less secure. Since the user information is already available through the JWT token (via req.user), we now fetch the user ID directly from there. This simplifies the request payload, enhances security by preventing client-side manipulation of userId, and aligns with best practices for handling authenticated user data.